### PR TITLE
Don't monitor network state in local mode (#20)

### DIFF
--- a/src/sk/vx/connectbot/service/TerminalManager.java
+++ b/src/sk/vx/connectbot/service/TerminalManager.java
@@ -201,6 +201,13 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 	 * Disconnect all currently connected bridges.
 	 */
 	private void disconnectAll(final boolean immediate) {
+        disconnectAll(immediate, false);
+    }
+
+	/**
+	 * Disconnect all currently connected bridges.
+	 */
+	private void disconnectAll(final boolean immediate, boolean onlyRemote) {
 		TerminalBridge[] tmpBridges = null;
 
 		synchronized (bridges) {
@@ -211,8 +218,10 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 
 		if (tmpBridges != null) {
 			// disconnect and dispose of any existing bridges
-			for (int i = 0; i < tmpBridges.length; i++)
-				tmpBridges[i].dispatchDisconnect(immediate);
+			for (int i = 0; i < tmpBridges.length; i++) {
+				if (!onlyRemote || !(tmpBridges[i].transport instanceof sk.vx.connectbot.transport.Local))
+                    tmpBridges[i].dispatchDisconnect(immediate);
+            }
 		}
 	}
 
@@ -666,7 +675,7 @@ public class TerminalManager extends Service implements BridgeDisconnectedListen
 		final Thread t = new Thread() {
 			@Override
 			public void run() {
-				disconnectAll(false);
+				disconnectAll(false, true);
 			}
 		};
 		t.setName("Disconnector");


### PR DESCRIPTION
Issue #20: When the phone loses a network connection, connectbot also disconnects local sessions.

Patch info: Based on upstream's issue #417 patch. Fixed to use instanceof instead of getProtocolName(): this method is static and will always return "unknown".
