### PR TITLE
Enable ctrl key on the Lenovo Thinkpad Tablet

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -156,12 +156,14 @@
 	<string-array name="list_custom_keymap" translatable="false">
 		<item>Samsung Captivate Glide (SGH-i927)</item>
 		<item>Sony Ericsson Xperia (mini) pro</item>
+		<item>Lenovo Thinkpad Tablet</item>
 		<item>@string/pref_custom_keymap_disabled</item>
 	</string-array>
 
 	<string-array name="list_custom_keymap_values" translatable="false">
 		<item>sgh_i927</item>
 		<item>se_xppro</item>
+		<item>lenovo_1838-CTO</item>
 		<item>none</item>
 	</string-array>
 </resources>

--- a/src/sk/vx/connectbot/service/TerminalKeyListener.java
+++ b/src/sk/vx/connectbot/service/TerminalKeyListener.java
@@ -781,7 +781,13 @@ public class TerminalKeyListener implements OnKeyListener, OnSharedPreferenceCha
 					break;
 				}
 			}
-		}
+		} else if (customKeyboard.equals(PreferenceConstants.CUSTOM_KEYMAP_LENOVO_1838_CTO)) {
+			if (keyCode == KeyEvent.KEYCODE_MENU) {
+				ctrlKeySpecial();
+				return true;
+			}
+
+        }
 
 		if (c != 0x00) {
 			try {

--- a/src/sk/vx/connectbot/util/PreferenceConstants.java
+++ b/src/sk/vx/connectbot/util/PreferenceConstants.java
@@ -109,4 +109,5 @@ public class PreferenceConstants {
 	public static final String CUSTOM_KEYMAP_DISABLED = "none";
 	public static final String CUSTOM_KEYMAP_SE_XPPRO = "se_xppro";
 	public static final String CUSTOM_KEYMAP_SGH_I927 = "sgh_i927";
+	public static final String CUSTOM_KEYMAP_LENOVO_1838_CTO = "lenovo_1838-CTO";
 }


### PR DESCRIPTION
On the Lenovo Thinkpad Tablet with the Folio case, the key marked "Ctrl" is configured to send KEY_MENU instead of sending CTRL. This edit adds a custom keyboard so that the Ctrl key works properly in VX Connectbot on the Lenovo tablet.
