### PR TITLE
Start ConsoleActivity explicitly

### DIFF
--- a/src/sk/vx/connectbot/HostListActivity.java
+++ b/src/sk/vx/connectbot/HostListActivity.java
@@ -188,6 +188,7 @@ public class HostListActivity extends ListActivity {
 
 				Intent contents = new Intent(Intent.ACTION_VIEW, uri);
 				contents.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+				contents.setClass(HostListActivity.this, ConsoleActivity.class);
 
 				if (makingShortcut) {
 					// create shortcut if requested


### PR DESCRIPTION
Old behaviour was to let the user decide which app to use. I think VX connectbot should explicitly reference its own ConsoleActivity class and not start activities of other apps.
