### PR TITLE
Socks client support

### DIFF
--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -321,8 +321,8 @@
   <string name="pref_ctrl_string">CTRL ablak tartalma</string>
   <string name="pref_ctrl_string_summary">Karakterek sorozata a CTRL+? kombinációkhoz.</string>
   <string name="fullscreen">Teljes képernyő</string>
-  <string name="hostpref_wantsession_title">"Héj indítása"</string>
-  <string name="hostpref_wantsession_summary">"Kapcsoljuk ki, ha csak port átirányításra van szükségünk"</string>
+  <!-- <string name="hostpref_wantsession_title">"Héj indítása"</string>
+  <string name="hostpref_wantsession_summary">"Kapcsoljuk ki, ha csak port átirányításra van szükségünk"</string> -->
   <string name="hostpref_x11_forwarding">"X11 átirányítás"</string>
   <string name="hostpref_wantx11forward_title">"X11 átirányítás bekapcsolása"</string>
   <string name="hostpref_wantx11forward_summary">"X11 munkamenetek átirányítása a lentebb megadott kiszolgálóra és portra"</string>

--- a/src/com/trilead/ssh2/SocksProxyData.java
+++ b/src/com/trilead/ssh2/SocksProxyData.java
@@ -1,0 +1,25 @@
+/**
+ *
+ */
+package com.trilead.ssh2;
+
+import java.net.UnknownHostException;
+
+import net.sourceforge.jsocks.Proxy;
+import net.sourceforge.jsocks.Socks5Proxy;
+
+/**
+ * @author dido
+ *
+ */
+public class SocksProxyData implements ProxyData
+{
+	public final Proxy proxy;
+
+	public SocksProxyData(String proxyhost, int proxyport) throws UnknownHostException
+	{
+		Socks5Proxy p = new Socks5Proxy(proxyhost, proxyport);
+		p.resolveAddrLocally(false);
+		proxy = p;
+	}
+}

--- a/src/net/sourceforge/jsocks/InetRange.java
+++ b/src/net/sourceforge/jsocks/InetRange.java
@@ -1,0 +1,447 @@
+package net.sourceforge.jsocks;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
+/**
+ * Class InetRange provides the means of defining the range of inetaddresses.
+ * It's used by Proxy class to store and look up addresses of machines, that
+ * should be contacted directly rather then through the proxy.
+ * <P>
+ * InetRange provides several methods to add either standalone addresses, or
+ * ranges (e.g. 100.200.300.0:100.200.300.255, which covers all addresses
+ * on on someones local network). It also provides methods for checking wether
+ * given address is in this range. Any number of ranges and standalone
+ * addresses can be added to the range.
+ */
+public class InetRange implements Cloneable{
+
+    Hashtable host_names;
+    Vector all;
+    Vector end_names;
+
+    boolean useSeparateThread = true;
+
+    /**
+     * Creates the empty range.
+     */
+    public InetRange(){
+      all = new Vector();
+      host_names = new Hashtable();
+      end_names = new Vector();
+    }
+
+    /**
+     *  Adds another host or range to this range.
+        The String can be one of those:
+        <UL>
+        <li> Host name. eg.(Athena.myhost.com or 45.54.56.65)
+
+        <li> Range in the form .myhost.net.au <BR>
+             In which case anything that ends with .myhost.net.au will
+             be considered in the range.
+
+        <li> Range in the form ddd.ddd.ddd. <BR>
+             This will be treated as range ddd.ddd.ddd.0 to ddd.ddd.ddd.255.
+             It is not necessary to specify 3 first bytes you can use just
+             one or two. For example 130. will cover address between 130.0.0.0
+             and 13.255.255.255.
+
+        <li> Range in the form host_from[: \t\n\r\f]host_to. <br>
+             That is two hostnames or ips separated by either whitespace
+             or colon.
+        </UL>
+     */
+    public synchronized boolean add(String s){
+      if(s == null) return false;
+
+      s = s.trim();
+      if(s.length() == 0) return false;
+
+      Object[] entry;
+
+      if(s.charAt(s.length()-1) == '.'){
+         //thing like: 111.222.33.
+         //it is being treated as range 111.222.33.000 - 111.222.33.255
+
+         int[] addr = ip2intarray(s);
+         long from,to;
+         from = to = 0;
+
+         if(addr == null) return false;
+         for(int i = 0; i< 4;++i){
+            if(addr[i]>=0)
+              from += (((long)addr[i]) << 8*(3-i));
+            else{
+              to = from;
+              while(i<4)
+                to += 255l << 8*(3-i++);
+              break;
+            }
+         }
+         entry = new Object[] {s,null,new Long(from),new Long(to)};
+         all.addElement(entry);
+
+      }else if(s.charAt(0) == '.'){
+         //Thing like: .myhost.com
+
+         end_names.addElement(s);
+         all.addElement(new Object[]{s,null,null,null});
+      }else{
+         StringTokenizer tokens = new StringTokenizer(s," \t\r\n\f:");
+         if(tokens.countTokens() > 1){
+           entry = new Object[] {s,null,null,null};
+           resolve(entry,tokens.nextToken(),tokens.nextToken());
+           all.addElement(entry);
+         }else{
+           entry = new Object[] {s,null,null,null};
+           all.addElement(entry);
+           host_names.put(s,entry);
+           resolve(entry);
+         }
+
+      }
+
+      return true;
+    }
+
+    /**
+     *  Adds another ip for this range.
+        @param ip IP os the host which should be added to this range.
+     */
+    public synchronized void add(InetAddress ip){
+       long from, to;
+       from = to = ip2long(ip);
+       all.addElement(new Object[]{ip.getHostName(),ip,new Long(from),
+                                                       new Long(to)});
+    }
+
+    /**
+     *  Adds another range of ips for this range.Any host with ip address
+        greater than or equal to the address of from and smaller than or equal
+        to the address of to will be included in the range.
+        @param from IP from where range starts(including).
+        @param to   IP where range ends(including).
+     */
+    public synchronized void add(InetAddress from,InetAddress to){
+       all.addElement(new Object[]{from.getHostAddress()+":"+to.getHostAddress()
+                            ,null,new Long(ip2long(from)),
+                                  new Long(ip2long(to))});
+    }
+
+    /**
+     * Checks wether the givan host is in the range. Attempts to resolve
+       host name if required.
+       @param host Host name to check.
+       @return true If host is in the range, false otherwise.
+     * @see InetRange#contains(String,boolean)
+     */
+    public synchronized boolean contains(String host){
+       return contains(host,true);
+    }
+
+    /**
+     *  Checks wether the given host is in the range.
+     *  <P>
+     *  Algorithm: <BR>
+     *  <ol>
+     *  <li>Look up if the hostname is in the range (in the Hashtable).
+     *  <li>Check if it ends with one of the speciefied endings.
+     *  <li>Check if it is ip(eg.130.220.35.98). If it is check if it is
+     *      in the range.
+     *  <li>If attemptResolve is true, host is name, rather than ip, and
+     *      all previous attempts failed, try to resolve the hostname, and
+     *      check wether the ip associated with the host is in the range.It
+     *      also repeats all previos steps with the hostname obtained from
+     *      InetAddress, but the name is not allways the full name,it is
+     *      quite likely to be the same. Well it was on my machine.
+     *  </ol>
+       @param host Host name to check.
+       @param attemptResolve Wether to lookup ip address which corresponds
+       to the host,if required.
+       @return true If host is in the range, false otherwise.
+     */
+    public synchronized boolean contains(String host,boolean attemptResolve){
+       if(all.size() ==0) return false; //Empty range
+
+       host = host.trim();
+       if(host.length() == 0) return false;
+
+       if(checkHost(host)) return true;
+       if(checkHostEnding(host)) return true;
+
+       long l = host2long(host);
+       if(l >=0) return contains(l);
+
+       if(!attemptResolve) return false;
+
+       try{
+          InetAddress ip = InetAddress.getByName(host);
+          return contains(ip);
+       }catch(UnknownHostException uhe){
+
+       }
+
+       return false;
+    }
+
+    /**
+     * Checks wether the given ip is in the range.
+       @param ip Address of the host to check.
+       @return true If host is in the range, false otherwise.
+     */
+    public synchronized boolean contains(InetAddress ip){
+       if(checkHostEnding(ip.getHostName())) return true;
+       if(checkHost(ip.getHostName())) return true;
+       return contains(ip2long(ip));
+    }
+    /**
+       Get all entries in the range as strings. <BR>
+       These strings can be used to delete entries from the range
+       with remove function.
+       @return Array of entries as strings.
+       @see InetRange#remove(String)
+     */
+    public synchronized String[] getAll(){
+       int size = all.size();
+       Object entry[];
+       String all_names[] = new String[size];
+
+       for(int i=0;i<size;++i){
+          entry = (Object[]) all.elementAt(i);
+          all_names[i] = (String) entry[0];
+       }
+       return all_names;
+    }
+    /**
+      Removes an entry from this range.<BR>
+      @param s Entry to remove.
+      @return true if successfull.
+     */
+    public synchronized boolean remove(String s){
+      Iterator iterator = all.iterator();
+
+      while(iterator.hasNext()){
+        Object[] entry = (Object[]) iterator.next();
+        if(s.equals(entry[0])){
+          all.removeElement(entry);
+          end_names.removeElement(s);
+          host_names.remove(s);
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** Get string representaion of this Range.*/
+    @Override
+	public String toString(){
+       String all[] = getAll();
+       if(all.length == 0) return "";
+
+       String s = all[0];
+       for(int i=1;i<all.length;++i)
+          s += "; "+all[i];
+       return s;
+    }
+
+    /** Creates a clone of this Object*/
+    @Override
+	public Object clone(){
+      InetRange new_range = new InetRange();
+      new_range.all = (Vector)all.clone();
+      new_range.end_names = (Vector) end_names.clone();
+      new_range.host_names = (Hashtable)host_names.clone();
+      return new_range;
+    }
+
+
+//Private methods
+/////////////////
+    /**
+     * Same as previous but used internally, to avoid
+     * unnecessary convertion of IPs, when checking subranges
+     */
+    private synchronized boolean contains(long ip){
+       Iterator iterator = all.iterator();
+       while(iterator.hasNext()){
+         Object[] obj = (Object[]) iterator.next();
+         Long from = obj[2]==null?null:(Long)obj[2];
+         Long to   = obj[3]==null?null:(Long)obj[3];
+         if(from != null && from.longValue()<= ip
+                         && to.longValue() >= ip) return true;
+
+       }
+       return false;
+    }
+
+    private boolean checkHost(String host){
+       return host_names.containsKey(host);
+    }
+    private boolean checkHostEnding(String host){
+       Iterator iterator = end_names.iterator();
+       while(iterator.hasNext()){
+          if(host.endsWith((String) iterator.next())) return true;
+       }
+       return false;
+    }
+    private void resolve(Object[] entry){
+       //First check if it's in the form ddd.ddd.ddd.ddd.
+       long ip = host2long((String) entry[0]);
+       if(ip >= 0){
+         entry[2] = entry[3] = new Long(ip);
+       }else{
+         InetRangeResolver res = new InetRangeResolver(entry);
+         res.resolve(useSeparateThread);
+       }
+    }
+    private void resolve(Object[] entry,String from,String to){
+       long f,t;
+       if((f=host2long(from))>= 0 && (t=host2long(to)) >= 0){
+         entry[2] = new Long(f);
+         entry[3] = new Long(t);
+       }else{
+         InetRangeResolver res = new InetRangeResolver(entry,from,to);
+         res.resolve(useSeparateThread);
+       }
+    }
+
+
+
+//Class methods
+///////////////
+
+    //Converts ipv4 to long value(unsigned int)
+    ///////////////////////////////////////////
+    static long ip2long(InetAddress ip){
+        long l=0;
+        byte[] addr = ip.getAddress();
+
+        if(addr.length ==4){ //IPV4
+          for(int i=0;i<4;++i)
+             l += (((long)addr[i] &0xFF) << 8*(3-i));
+        }else{ //IPV6
+          return 0;  //Have no idea how to deal with those
+        }
+        return l;
+    }
+
+
+    long host2long(String host){
+      long ip=0;
+
+      //check if it's ddd.ddd.ddd.ddd
+      if(!Character.isDigit(host.charAt(0))) return -1;
+
+      int[] addr = ip2intarray(host);
+      if(addr == null) return -1;
+
+      for(int i=0;i<addr.length;++i)
+          ip += ((long)(addr[i]>=0 ? addr[i] : 0)) << 8*(3-i);
+
+      return ip;
+    }
+
+    static int[] ip2intarray(String host){
+       int[] address = {-1,-1,-1,-1};
+       int i=0;
+       StringTokenizer tokens = new StringTokenizer(host,".");
+       if(tokens.countTokens() > 4) return null;
+       while(tokens.hasMoreTokens()){
+         try{
+           address[i++] = Integer.parseInt(tokens.nextToken()) & 0xFF;
+         }catch(NumberFormatException nfe){
+            return null;
+         }
+
+       }
+       return address;
+    }
+
+
+/*
+//* This was the test main function
+//**********************************
+
+    public static void main(String args[])throws UnknownHostException{
+       int i;
+
+       InetRange ir = new InetRange();
+
+
+       for(i=0;i<args.length;++i){
+         System.out.println("Adding:" + args[i]);
+         ir.add(args[i]);
+       }
+
+       String host;
+       java.io.DataInputStream din = new java.io.DataInputStream(System.in);
+       try{
+          host = din.readLine();
+          while(host!=null){
+            if(ir.contains(host)){
+              System.out.println("Range contains ip:"+host);
+            }else{
+              System.out.println(host+" is not in the range");
+            }
+            host = din.readLine();
+          }
+       }catch(java.io.IOException io_ex){
+          io_ex.printStackTrace();
+       }
+    }
+********************/
+
+}
+
+
+class InetRangeResolver implements Runnable{
+
+   Object[] entry;
+
+   String from, to;
+
+   InetRangeResolver(Object[] entry){
+      this.entry = entry;
+      from = to = null;
+   }
+   InetRangeResolver(Object[] entry,String from,String to){
+      this.entry = entry;
+      this.from  = from;
+      this.to    = to;
+   }
+   public final void resolve(){
+     resolve(true);
+   }
+   public final void resolve(boolean inSeparateThread){
+     if(inSeparateThread){
+       Thread t = new Thread(this);
+       t.start();
+     }else
+       run();
+
+   }
+   public void run(){
+     try{
+        if(from == null){
+          InetAddress ip = InetAddress.getByName((String) entry[0]);
+          entry[1] = ip;
+          Long l = new Long(InetRange.ip2long(ip));
+          entry[2] = entry[3] = l;
+        }else{
+          InetAddress f = InetAddress.getByName(from);
+          InetAddress t = InetAddress.getByName(to);
+          entry[2] = new Long(InetRange.ip2long(f));
+          entry[3] = new Long(InetRange.ip2long(t));
+
+        }
+     }catch(UnknownHostException uhe){
+        //System.err.println("Resolve failed for "+from+','+to+','+entry[0]);
+     }
+   }
+
+}

--- a/src/net/sourceforge/jsocks/Socks5Proxy.java
+++ b/src/net/sourceforge/jsocks/Socks5Proxy.java
@@ -1,4 +1,5 @@
 package net.sourceforge.jsocks;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -16,7 +17,7 @@ import java.util.Hashtable;
 public class Socks5Proxy extends Proxy implements Cloneable{
 
 //Data members
-   private Hashtable<Integer, Authentication> authMethods = new Hashtable<Integer, Authentication>();
+   private Hashtable authMethods = new Hashtable();
    private int selectedMethod;
 
    boolean resolveAddrLocally = true;
@@ -28,17 +29,41 @@ public class Socks5Proxy extends Proxy implements Cloneable{
 
    /**
      Creates SOCKS5 proxy.
+     @param p Proxy to use to connect to this proxy, allows proxy chaining.
+     @param proxyHost Host on which a Proxy server runs.
+     @param proxyPort Port on which a Proxy server listens for connections.
+     @throws UnknownHostException If proxyHost can't be resolved.
+   */
+   public Socks5Proxy(Proxy p,String proxyHost,int proxyPort)
+          throws UnknownHostException{
+      super(p,proxyHost,proxyPort);
+      version = 5;
+      setAuthenticationMethod(0,new AuthenticationNone());
+   }
+
+   /**
+     Creates SOCKS5 proxy.
      @param proxyHost Host on which a Proxy server runs.
      @param proxyPort Port on which a Proxy server listens for connections.
      @throws UnknownHostException If proxyHost can't be resolved.
    */
    public Socks5Proxy(String proxyHost,int proxyPort)
           throws UnknownHostException{
-      super(proxyHost,proxyPort);
+      this(null,proxyHost,proxyPort);
+   }
+
+
+   /**
+     Creates SOCKS5 proxy.
+     @param p Proxy to use to connect to this proxy, allows proxy chaining.
+     @param proxyIP Host on which a Proxy server runs.
+     @param proxyPort Port on which a Proxy server listens for connections.
+   */
+   public Socks5Proxy(Proxy p,InetAddress proxyIP,int proxyPort){
+      super(p,proxyIP,proxyPort);
       version = 5;
       setAuthenticationMethod(0,new AuthenticationNone());
    }
-
 
    /**
      Creates SOCKS5 proxy.
@@ -46,14 +71,18 @@ public class Socks5Proxy extends Proxy implements Cloneable{
      @param proxyPort Port on which a Proxy server listens for connections.
    */
    public Socks5Proxy(InetAddress proxyIP,int proxyPort){
-      super(proxyIP,proxyPort);
-      version = 5;
-      setAuthenticationMethod(0,new AuthenticationNone());
+      this(null,proxyIP,proxyPort);
    }
-
 
 //Public instance methods
 //========================
+
+  /**
+     set the local socket port
+   */
+  public void setLocalSocketPort(int portNum) {
+    this.localSocketPort = portNum;
+  }
 
 
    /**
@@ -91,9 +120,9 @@ public class Socks5Proxy extends Proxy implements Cloneable{
           return false;
       if(method == null){
         //Want to remove a particular method
-	return (authMethods.remove(Integer.valueOf(methodId)) != null);
+	return (authMethods.remove(new Integer(methodId)) != null);
       }else{//Add the method, or rewrite old one
-	authMethods.put(Integer.valueOf(methodId),method);
+	authMethods.put(new Integer(methodId),method);
       }
       return true;
    }
@@ -104,7 +133,7 @@ public class Socks5Proxy extends Proxy implements Cloneable{
     @return Implementation for given method or null, if one was not set.
    */
    public Authentication getAuthenticationMethod(int methodId){
-      Object method = authMethods.get(Integer.valueOf(methodId));
+      Object method = authMethods.get(new Integer(methodId));
       if(method == null) return null;
       return (Authentication)method;
    }
@@ -113,10 +142,10 @@ public class Socks5Proxy extends Proxy implements Cloneable{
     Creates a clone of this Proxy.
    */
    @Override
-@SuppressWarnings("unchecked")
 public Object clone(){
       Socks5Proxy newProxy = new Socks5Proxy(proxyIP,proxyPort);
-      newProxy.authMethods = (Hashtable<Integer, Authentication>) this.authMethods.clone();
+      newProxy.authMethods = (Hashtable) this.authMethods.clone();
+      newProxy.directHosts = (InetRange)directHosts.clone();
       newProxy.resolveAddrLocally = resolveAddrLocally;
       newProxy.chainProxy = chainProxy;
       return newProxy;
@@ -133,8 +162,10 @@ public Object clone(){
 protected Proxy copy(){
        Socks5Proxy copy = new Socks5Proxy(proxyIP,proxyPort);
        copy.authMethods = this.authMethods; //same Hash, no copy
+       copy.directHosts = this.directHosts;
        copy.chainProxy = this.chainProxy;
        copy.resolveAddrLocally = this.resolveAddrLocally;
+       copy.localSocketPort = this.localSocketPort;
        return copy;
     }
    /**
@@ -148,70 +179,69 @@ protected void startSession()throws SocksException{
       Socket ps = proxySocket; //The name is too long
 
       try{
+        byte nMethods = (byte) authMethods.size();  //Number of methods
 
-	 byte nMethods = (byte) authMethods.size();  //Number of methods
+        byte[] buf = new byte[2+nMethods]; //2 is for VER,NMETHODS
+        buf[0] = (byte) version;
+        buf[1] = nMethods;                 //Number of methods
+        int i=2;
 
-         byte[] buf = new byte[2+nMethods]; //2 is for VER,NMETHODS
-         buf[0] = (byte) version;
-         buf[1] = nMethods;                 //Number of methods
-         int i=2;
+        Enumeration ids = authMethods.keys();
+        while(ids.hasMoreElements())
+          buf[i++] = (byte)((Integer)ids.nextElement()).intValue();
 
-         Enumeration<Integer> ids = authMethods.keys();
-         while(ids.hasMoreElements())
-            buf[i++] = (byte)ids.nextElement().intValue();
+        out.write(buf);
+        out.flush();
 
-         out.write(buf);
-         out.flush();
+        int versionNumber  = in.read();
+        selectedMethod = in.read();
 
-         int versionNumber  = in.read();
-         selectedMethod = in.read();
+        if(versionNumber < 0 || selectedMethod < 0){
+          //EOF condition was reached
+          endSession();
+          throw(new SocksException(SOCKS_PROXY_IO_ERROR,
+          "Connection to proxy lost."));
+        }
+        if(versionNumber < version){
+          //What should we do??
+        }
+        if(selectedMethod == 0xFF){ //No method selected
+          ps.close();
+          throw ( new SocksException(SOCKS_AUTH_NOT_SUPPORTED));
+        }
 
-         if(versionNumber < 0 || selectedMethod < 0){
-           //EOF condition was reached
-           endSession();
-           throw(new SocksException(SOCKS_PROXY_IO_ERROR,
-                 "Connection to proxy lost."));
-         }
-         if(versionNumber < version){
-           //What should we do??
-         }
-         if(selectedMethod == 0xFF){ //No method selected
-            ps.close();
-            throw ( new SocksException(SOCKS_AUTH_NOT_SUPPORTED));
-         }
+        auth = getAuthenticationMethod(selectedMethod);
+        if(auth == null){
+          //This shouldn't happen, unless method was removed by other
+          //thread, or the server stuffed up
+          throw(new SocksException(SOCKS_JUST_ERROR,
+          "Speciefied Authentication not found!"));
+        }
+        Object[] in_out = auth.doSocksAuthentication(selectedMethod,ps);
+        if(in_out == null){
+          //Authentication failed by some reason
+          throw(new SocksException(SOCKS_AUTH_FAILURE));
+        }
+        //Most authentication methods are expected to return
+        //simply the input/output streams associated with
+        //the socket. However if the auth. method requires
+        //some kind of encryption/decryption being done on the
+        //connection it should provide classes to handle I/O.
 
-         auth = getAuthenticationMethod(selectedMethod);
-         if(auth == null){
-            //This shouldn't happen, unless method was removed by other
-            //thread, or the server stuffed up
-            throw(new SocksException(SOCKS_JUST_ERROR,
-                      "Speciefied Authentication not found!"));
-         }
-         Object[] in_out = auth.doSocksAuthentication(selectedMethod,ps);
-         if(in_out == null){
-            //Authentication failed by some reason
-            throw(new SocksException(SOCKS_AUTH_FAILURE));
-         }
-         //Most authentication methods are expected to return
-         //simply the input/output streams associated with
-         //the socket. However if the auth. method requires
-         //some kind of encryption/decryption being done on the
-         //connection it should provide classes to handle I/O.
-
-         in = (InputStream) in_out[0];
-         out = (OutputStream) in_out[1];
-         if(in_out.length > 2)
-            udp_encapsulation = (UDPEncapsulation) in_out[2];
+        in = (InputStream) in_out[0];
+        out = (OutputStream) in_out[1];
+        if(in_out.length > 2)
+          udp_encapsulation = (UDPEncapsulation) in_out[2];
 
       }catch(SocksException s_ex){
-         throw s_ex;
+        throw s_ex;
       }catch(UnknownHostException uh_ex){
-         throw(new SocksException(SOCKS_PROXY_NO_CONNECT));
+        throw(new SocksException(SOCKS_PROXY_NO_CONNECT));
       }catch(SocketException so_ex){
-         throw(new SocksException(SOCKS_PROXY_NO_CONNECT));
+        throw(new SocksException(SOCKS_PROXY_NO_CONNECT));
       }catch(IOException io_ex){
-         //System.err.println(io_ex);
-         throw(new SocksException(SOCKS_PROXY_IO_ERROR,""+io_ex));
+        //System.err.println(io_ex);
+        throw(new SocksException(SOCKS_PROXY_IO_ERROR,""+io_ex));
       }
    }
 

--- a/src/net/sourceforge/jsocks/SocksServerException.java
+++ b/src/net/sourceforge/jsocks/SocksServerException.java
@@ -1,0 +1,19 @@
+package net.sourceforge.jsocks;
+
+public class SocksServerException extends Exception {
+
+  String message;
+
+  public SocksServerException(Exception e) {
+    this.message = e.getMessage();
+  }
+
+  public SocksServerException(String message) {
+    this.message = message;
+  }
+  
+  @Override
+  public String getMessage() {
+    return message;
+  }
+}

--- a/src/net/sourceforge/jsocks/UserPasswordAuthentication.java
+++ b/src/net/sourceforge/jsocks/UserPasswordAuthentication.java
@@ -1,0 +1,75 @@
+package net.sourceforge.jsocks;
+
+/**
+  SOCKS5 User Password authentication scheme.
+*/
+public class UserPasswordAuthentication implements Authentication{
+
+   /**SOCKS ID for User/Password authentication method*/
+   public final static int METHOD_ID = 2;
+
+   String userName, password;
+   byte[] request;
+
+   /**
+     Create an instance of UserPasswordAuthentication.
+     @param userName User Name to send to SOCKS server.
+     @param password Password to send to SOCKS server.
+   */
+   public UserPasswordAuthentication(String userName,String password){
+     this.userName = userName;
+     this.password = password;
+     formRequest();
+   }
+   /** Get the user name.
+   @return User name.
+   */
+   public String getUser(){
+     return userName;
+   }
+   /** Get password
+   @return Password
+   */
+   public String getPassword(){
+     return password;
+   }
+   /**
+    Does User/Password authentication as defined in rfc1929.
+    @return An array containnig in, out streams, or null if authentication
+    fails.
+   */
+   public Object[] doSocksAuthentication(int methodId,
+                                         java.net.Socket proxySocket)
+                   throws java.io.IOException{
+
+      if(methodId != METHOD_ID) return null;
+
+      java.io.InputStream in = proxySocket.getInputStream();
+      java.io.OutputStream out = proxySocket.getOutputStream();
+
+      out.write(request);
+      int version = in.read();
+      if(version < 0) return null; //Server closed connection
+      int status = in.read();
+      if(status != 0) return null; //Server closed connection, or auth failed.
+
+      return new Object[] {in,out};
+   }
+
+//Private methods
+//////////////////
+
+/** Convert UserName password in to binary form, ready to be send to server*/
+   private void formRequest(){
+      byte[] user_bytes = userName.getBytes();
+      byte[] password_bytes = password.getBytes();
+
+      request = new byte[3+user_bytes.length+password_bytes.length];
+      request[0] = (byte) 1;
+      request[1] = (byte) user_bytes.length;
+      System.arraycopy(user_bytes,0,request,2,user_bytes.length);
+      request[2+user_bytes.length] = (byte) password_bytes.length;
+      System.arraycopy(password_bytes,0,
+                       request,3+user_bytes.length,password_bytes.length);
+   }
+}

--- a/src/sk/vx/connectbot/bean/HostBean.java
+++ b/src/sk/vx/connectbot/bean/HostBean.java
@@ -349,5 +349,4 @@ public class HostBean extends AbstractBean {
 			.append(nickname);
 		return Uri.parse(sb.toString());
 	}
-
 }

--- a/src/sk/vx/connectbot/transport/SSH.java
+++ b/src/sk/vx/connectbot/transport/SSH.java
@@ -23,8 +23,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URL;
-import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -59,14 +60,15 @@ import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.ConnectionInfo;
 import com.trilead.ssh2.ConnectionMonitor;
 import com.trilead.ssh2.DynamicPortForwarder;
+import com.trilead.ssh2.HTTPProxyData;
+import com.trilead.ssh2.HTTPProxyException;
 import com.trilead.ssh2.InteractiveCallback;
 import com.trilead.ssh2.KnownHosts;
 import com.trilead.ssh2.LocalPortForwarder;
 import com.trilead.ssh2.SCPClient;
 import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.Session;
-import com.trilead.ssh2.HTTPProxyData;
-import com.trilead.ssh2.HTTPProxyException;
+import com.trilead.ssh2.SocksProxyData;
 import com.trilead.ssh2.crypto.PEMDecoder;
 import com.trilead.ssh2.signature.DSAPrivateKey;
 import com.trilead.ssh2.signature.DSAPublicKey;
@@ -108,7 +110,8 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 	}
 
 	private boolean compression = false;
-	private String httpproxy = null;
+//	private String httpproxy = null;
+	private String httpproxy = "socks5://10.0.2.2:9050";
 	private volatile boolean authenticated = false;
 	private volatile boolean connected = false;
 	private volatile boolean sessionOpen = false;
@@ -427,28 +430,43 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 		}
 
 		if (httpproxy != null && httpproxy.length() > 0) {
-			Log.d(TAG, "Want HTTP Proxy: "+httpproxy, null);
+			boolean socksProxy = false;
+			Log.d(TAG, "Want HTTP/SOCKS Proxy: "+httpproxy, null);
 			try {
-                                URL u;
-                                if (httpproxy.startsWith("http://")) {
-				        u = new URL(httpproxy);
-                                } else {
-				        u = new URL("http://" + httpproxy);
-                                }
-				connection.setProxyData(new HTTPProxyData(
-					u.getHost(),
-					u.getPort(),
-					u.getUserInfo(),
-					u.getAuthority()));
-			        bridge.outputLine("Connecting via proxy: "+httpproxy);
-			} catch (MalformedURLException e) {
+				URI u;
+				if (httpproxy.startsWith("http://")) {
+					u = new URI(httpproxy);
+				} else if (httpproxy.startsWith("socks5://")) {
+					u = new URI(httpproxy);
+					socksProxy = true;
+				} else {
+					u = new URI("http://" + httpproxy);
+				}
+				if (socksProxy) {
+					connection.setProxyData(new SocksProxyData(u.getHost(), u.getPort()));
+				} else {
+					connection.setProxyData(new HTTPProxyData(
+							u.getHost(),
+							u.getPort(),
+							u.getUserInfo(),
+							u.getAuthority()));
+				}
+				bridge.outputLine("Connecting via proxy: "+httpproxy);
+			} catch (URISyntaxException e) {
 				Log.e(TAG, "Could not parse proxy "+httpproxy, e);
 
-			        // Display the reason in the text.
-			        bridge.outputLine("Bad proxy URL: "+httpproxy);
+				// Display the reason in the text.
+				bridge.outputLine("Bad proxy URL: "+httpproxy);
 
-			        onDisconnect();
-			        return;
+				onDisconnect();
+				return;
+			} catch (UnknownHostException e) {
+				Log.e(TAG, "Cannot connect to SOCKS proxy "+httpproxy, e);
+
+				// Display the reason in the text.
+				bridge.outputLine("Bad proxy specified: "+httpproxy);
+				onDisconnect();
+				return;
 			}
 		}
 
@@ -589,7 +607,7 @@ public class SSH extends AbsTransport implements ConnectionMonitor, InteractiveC
 		Map<String, String> options = new HashMap<String, String>();
 
 		options.put("compression", Boolean.toString(compression));
-                if (httpproxy != null)
+		if (httpproxy != null)
 			options.put("httpproxy", httpproxy);
 
 		return options;


### PR DESCRIPTION
I've basically made some simple changes that permit VX Connectbot to connect to SOCKS5 proxies. It uses the HTTP proxy configuration portion when you edit the host, and putting in a URL like socks5://my.socks.server:1080 (pre-patch this only permits HTTP proxies), you can use a SOCKS5 proxy to connect. I've used this to good effect connecting to some personal Tor hidden services with the help of Orbot. (socks5://127.0.0.1:9050 suffices for this).

I've needed to merge some of the jsocks upstream code in order to get this to work, and made a few changes to the trilead SSH code to make it use a SocksSocket instead of a plain socket, and to use SOCKS-based DNS resolution rather than local DNS.

This feature obviously requires a bit of cleanup before it's ready, but it's a start I think.
