### PR TITLE
Enable automatic close on disconnect (for automation)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -662,4 +662,7 @@
 	<string name="pref_ctrl_string_summary">String of characters for the CTRL+? combination</string>
 
 	<string name="fullscreen">Fullscreen</string>
+
+    <string name="hostpref_quickdisconnect_title">Close on disconnect</string>
+    <string name="hostpref_quickdisconnect_summary">Close immediately after remote disconnect without prompting.</string>
 </resources>

--- a/res/xml/host_prefs.xml
+++ b/res/xml/host_prefs.xml
@@ -92,6 +92,12 @@
 		android:summary="@string/hostpref_stayconnected_summary"
 		/>
 
+    <CheckBoxPreference
+        	android:key="quickdisconnect"
+        	android:title="@string/hostpref_quickdisconnect_title"
+        	android:summary="@string/hostpref_quickdisconnect_summary"
+        	/>
+
 	<ListPreference
 		android:key="delkey"
 		android:title="@string/hostpref_delkey_title"

--- a/src/sk/vx/connectbot/bean/HostBean.java
+++ b/src/sk/vx/connectbot/bean/HostBean.java
@@ -53,8 +53,9 @@ public class HostBean extends AbstractBean {
 	private boolean wantX11Forward = false;
 	private String x11Host = "localhost";
 	private int x11Port = 6000;
+    private boolean quickDisconnect = true;
 
-	public HostBean() {
+    public HostBean() {
 
 	}
 
@@ -207,6 +208,14 @@ public class HostBean extends AbstractBean {
 		this.stayConnected = stayConnected;
 	}
 
+    public void setQuickDisconnect(boolean quickDisconnect) {
+        this.quickDisconnect = quickDisconnect;
+    }
+
+    public boolean getQuickDisconnect() {
+        return quickDisconnect;
+    }
+
 	public boolean getStayConnected() {
 		return stayConnected;
 	}
@@ -271,6 +280,7 @@ public class HostBean extends AbstractBean {
 		values.put(HostDatabase.FIELD_HOST_WANTX11FORWARD, wantX11Forward);
 		values.put(HostDatabase.FIELD_HOST_X11HOST, x11Host);
 		values.put(HostDatabase.FIELD_HOST_X11PORT, x11Port);
+        values.put(HostDatabase.FIELD_HOST_QUICKDISCONNECT, quickDisconnect);
 		return values;
 	}
 

--- a/src/sk/vx/connectbot/service/TerminalBridge.java
+++ b/src/sk/vx/connectbot/service/TerminalBridge.java
@@ -456,7 +456,7 @@ public class TerminalBridge implements VDUDisplay {
 		disconnectThread.setName("Disconnect");
 		disconnectThread.start();
 
-		if (immediate) {
+        if (immediate || (host.getQuickDisconnect() && !host.getStayConnected())) {
 			awaitingClose = true;
 			if (disconnectListener != null)
 				disconnectListener.onDisconnected(TerminalBridge.this);

--- a/src/sk/vx/connectbot/util/HostDatabase.java
+++ b/src/sk/vx/connectbot/util/HostDatabase.java
@@ -46,7 +46,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 	public final static String TAG = "ConnectBot.HostDatabase";
 
 	public final static String DB_NAME = "hosts";
-	public final static int DB_VERSION = 24;
+	public final static int DB_VERSION = 25;
 
 	public final static String TABLE_HOSTS = "hosts";
 	public final static String FIELD_HOST_NICKNAME = "nickname";
@@ -69,6 +69,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
         public final static String FIELD_HOST_HTTPPROXY = "httpproxy";
 	public final static String FIELD_HOST_ENCODING = "encoding";
 	public final static String FIELD_HOST_STAYCONNECTED = "stayconnected";
+    public final static String FIELD_HOST_QUICKDISCONNECT = "quickdisconnect";
 	public final static String FIELD_HOST_WANTX11FORWARD = "wantx11forward";
 	public final static String FIELD_HOST_X11HOST = "x11host";
 	public final static String FIELD_HOST_X11PORT = "x11port";
@@ -188,7 +189,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 				+ FIELD_PORTFORWARD_TYPE + " TEXT NOT NULL DEFAULT " + PORTFORWARD_LOCAL + ", "
 				+ FIELD_PORTFORWARD_SOURCEPORT + " INTEGER NOT NULL DEFAULT 8080, "
 				+ FIELD_PORTFORWARD_DESTADDR + " TEXT, "
-				+ FIELD_PORTFORWARD_DESTPORT + " TEXT)");
+				+ FIELD_PORTFORWARD_DESTPORT + " TEXT,"
+                + FIELD_HOST_QUICKDISCONNECT + " TEXT)");
 
 		db.execSQL("CREATE INDEX " + TABLE_PORTFORWARDS + FIELD_PORTFORWARD_HOSTID + "index ON "
 				+ TABLE_PORTFORWARDS + " (" + FIELD_PORTFORWARD_HOSTID + ");");
@@ -279,6 +281,10 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 		case 23:
 			db.execSQL("ALTER TABLE " + TABLE_HOSTS
 					+ " ADD COLUMN " + FIELD_HOST_HTTPPROXY + " TEXT");
+
+        case 24:
+            db.execSQL("ALTER TABLE " + TABLE_HOSTS
+                    + " ADD COLUMN " + FIELD_HOST_QUICKDISCONNECT + " TEXT");
 		}
 	}
 
@@ -400,7 +406,8 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			COL_STAYCONNECTED = c.getColumnIndexOrThrow(FIELD_HOST_STAYCONNECTED),
 			COL_WANTX11FORWARD = c.getColumnIndexOrThrow(FIELD_HOST_WANTX11FORWARD),
 			COL_X11HOST = c.getColumnIndexOrThrow(FIELD_HOST_X11HOST),
-			COL_X11PORT = c.getColumnIndexOrThrow(FIELD_HOST_X11PORT);
+			COL_X11PORT = c.getColumnIndexOrThrow(FIELD_HOST_X11PORT),
+            COL_QUICKDISCONNECT = c.getColumnIndexOrThrow(FIELD_HOST_QUICKDISCONNECT);
 
 		while (c.moveToNext()) {
 			HostBean host = new HostBean();
@@ -427,6 +434,7 @@ public class HostDatabase extends RobustSQLiteOpenHelper {
 			host.setWantX11Forward(Boolean.valueOf(c.getString(COL_WANTX11FORWARD)));
 			host.setX11Host(c.getString(COL_X11HOST));
 			host.setX11Port(c.getInt(COL_X11PORT));
+            host.setQuickDisconnect(Boolean.valueOf(c.getString(COL_QUICKDISCONNECT)));
 
 			hosts.add(host);
 		}


### PR DESCRIPTION
Currently: When launching a shortcut connection from Tasker or other automation app, the app stays in focus on the phone screen even after disconnecting.  This pull request is to allow the app to  automatically disconnect and close when a connection has been terminated.  It respects the 'stay connected' flag.  

![image](https://f.cloud.github.com/assets/746276/2505921/4cf56c32-b39f-11e3-8a4b-11009d038a5b.png)

This pull request adds a 'Close on disconnect' option

![image](https://f.cloud.github.com/assets/746276/2505928/759fecac-b39f-11e3-8c59-dd3d620da11e.png)

This will allow the connection to disconnect without prompting, which is favorable for automation.  

_This patch was originally posted [here](https://code.google.com/r/peffreyking-connectbot/source/detail?r=6db98fe935581f27fd86a50748497a45ce53b9f3&name=quick-disconnect) and [here](https://github.com/connectbot/connectbot/pull/23)_
